### PR TITLE
save and load state

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_style = tab

--- a/KRandTesting/KRandTesting.csproj
+++ b/KRandTesting/KRandTesting.csproj
@@ -20,6 +20,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<ProjectReference Include="..\KRand\KRand.csproj" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 	</ItemGroup>
 
 </Project>

--- a/KRandTesting/StateTests.cs
+++ b/KRandTesting/StateTests.cs
@@ -1,0 +1,71 @@
+using Xunit;
+
+using FluentAssertions;
+
+using System;
+using System.Linq;
+
+namespace Kermalis.KRand.Tests;
+
+public sealed class StateTests
+{
+	[Fact]
+	public void GetState_ShouldReturnValue()
+	{
+		var rand = new KRand();
+
+		// Ensure state is returned
+		var state = rand.GetState();
+		state.Should().NotBeNullOrWhiteSpace();
+
+		// Ensure state has requisite number of parts
+		var parts = state.Split(':');
+		parts.Should().HaveCount(13);
+	}
+
+	[Fact]
+	public void Constructor_NullStateShouldThrowException()
+	{
+		Action constructor = () => new KRand(null as string);
+		constructor.Should().Throw<ArgumentNullException>();
+	}
+
+	[Fact]
+	public void Constructor_EmptyStateShouldThrowException()
+	{
+		Action constructor = () => new KRand(" ");
+		constructor.Should().Throw<ArgumentException>();
+	}
+
+	[Fact]
+	public void Constructor_TamperedStateShouldThrowException()
+	{
+		var rand = new KRand();
+		var state = rand.GetState();
+		state = state[..^1];
+
+		Action constructor = () => new KRand(state);
+		constructor.Should().Throw<ArgumentException>().WithMessage("State is corrupt.");
+	}
+
+	[Fact]
+	public void RestoringStateShouldAllowSequenceReplication()
+	{
+		// Create a rand and generate a 100 numbers
+		var original = new KRand();
+		_ = Enumerable.Range(0, 100).Select(_ => original.NextInt32(-100, 100)).ToArray();
+
+		// Persist the state and generate another 100 numbers
+		var state = original.GetState();
+		var expected = Enumerable.Range(0, 100).Select(_ => original.NextInt32(-100, 100)).ToArray();
+
+		// Restore the previous state and generate another 100 numbers
+		var restored = new KRand(state);
+		var actual = Enumerable.Range(0, 100).Select(_ => restored.NextInt32(-100, 100)).ToArray();
+
+		// The numbers generated after persisting the state
+		// And the numbers generated after restoring the state
+		// should be identical.
+		actual.Should().BeEquivalentTo(expected);
+	}
+}


### PR DESCRIPTION
Allows for the state of the random number generator to be persisted and then restored (and validated) later.

This allows for use cases where the sequence of numbers generated needs to remain consistent between application runs and be resistant to tampering.